### PR TITLE
correction of frontal slices in tensor_manipulation.ipynb

### DIFF
--- a/01_tensor_basics/tensor_manipulation.ipynb
+++ b/01_tensor_basics/tensor_manipulation.ipynb
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can view the frontal slices by fixing the last axis:"
+    "You can view the frontal slices by fixing the first axis:"
    ]
   },
   {


### PR DESCRIPTION
extract frontal slices by fixing the first axis instead of the last axis